### PR TITLE
Rework serc_safe into serc_safe_open

### DIFF
--- a/src/edit.h
+++ b/src/edit.h
@@ -31,7 +31,7 @@ int optpat(char lin[], int *i);
 int ptscan(int way, int *num);
 int settab(char str[]);
 void serc(void);
-int serc_safe (char *path);
+FILE *serc_safe_open (char *path);
 char *sysname(void);
 void log_usage(void);
 


### PR DESCRIPTION
Closes a small race condition that could occur between checking if serc is safe and reading it. Also fix HAVE_STAT check while here.
