### PR TITLE
Minor clean-up to generate `configure` script et al.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ compile
 test-driver
 *.log
 *.trs
+# TextPad workspace
+*.tws

--- a/INSTALL
+++ b/INSTALL
@@ -5,8 +5,7 @@ scripts which will configure the build system. If there is
 not a 'configure' script present, run these commands to
 generate one based on the settings in configure.ac:
 
-	$ autoconf
-	$ automake
+	$ make -f Makefile.am reconf
 
 You can use the configure script to configure the build.
 Run `./configure --help` for a complete list of options.

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,3 +6,12 @@ sampledir = $(datadir)/@PACKAGE@
 sample_DATA = sample.serc
 
 EXTRA_DIST = $(sample_DATA) COPYING ChangeLog NEWS README TODO
+
+treeclean:
+	git clean -d -f -e "*.tws" -x
+
+reconf: treeclean
+	autoreconf -i -f
+
+list:
+	git ls-tree -r --name-only --full-tree HEAD

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,8 @@ dnl
 dnl Look for a working C compiler
 dnl
 
-AC_SEARCH_LIBS([strerror],[cposix])
 AC_PROG_CC
+AC_SEARCH_LIBS([strerror],[cposix])
 
 dnl
 dnl Give the user the option of enabling usage logging.


### PR DESCRIPTION
Have revised my earlier patch GH-16.  Have built and tested on Cygwin environment.  `.gitignore` continues to hide generated files to avoid accidentally adding to the repo.  Created make targets `treeclean` to take advantage of `git clean` to return a repo to a clean state and added `reconf` to hide the details of regenerating `configure` (did not realise `autoreconf` handled the combined `aclocal`, `autoconf`, `automake` until had a reread of the docs).
